### PR TITLE
Fix NameError: name 'path' is not defined.

### DIFF
--- a/MiUnlockTool.py
+++ b/MiUnlockTool.py
@@ -340,7 +340,7 @@ if "code" in r and r["code"] == 0:
     CheckB(cmd, "serialno", "getvar", "serialno")
     sys.stdout.write('\r\033[K')
     try:
-        result_stage = subprocess.run([cmd, "stage", path], check=True, capture_output=True, text=True)
+        result_stage = subprocess.run([cmd, "stage", "encryptData"], check=True, capture_output=True, text=True)
         result_unlock = subprocess.run([cmd, "oem", "unlock"], check=True, capture_output=True, text=True)
         print(f"\n{cg}Unlock successful{cgg}\n")
         os.remove("encryptData")


### PR DESCRIPTION
I got the following error in Arch Linux:

> Traceback (most recent call last):
>   File "/home/jsphthrn/Downloads/MiUnlockTool/MiUnlockTool.py", line 343, in <module>
>     result_stage = subprocess.run([cmd, "stage", path], check=True, capture_output=True, text=True)
>                                                  ^^^^
> NameError: name 'path' is not defined

After checking the code, I assumed this path was referring to encryptData file generated in the same folder.

Maybe is just a specific fix for my case only but letting you know nevertheless.

Hope this is useful.