### PR TITLE
Add instructions for installing in venv

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,18 +23,141 @@
 ---
 
 ## Installation
+<h4>
+  
+An automatic installer for termux can be found [here](#quick-install-for-androidtermux)
 
+</h4>
+
+<h3> Step 1 </h3>
+<p>Install Python</p>
+
+<details>
+<summary> Windows </summary>
+<br>
+
+You can download the installer [directly](https://www.python.org/downloads/) from Python's website or via WinGet:
 ```sh
+winget search Python.Python
+# Replace 3.14 with the latest version
+winget install Python.Python.3.14
+```
+</details>
+
+<details>
+<summary> macOS </summary>
+<br>
+
+You can download the installer [directly](https://www.python.org/downloads/) from Python's website or via [Homebrew](https://brew.sh/):
+```
+brew install --cask python
+```
+</details>
+
+
+<details>
+<summary> Termux </summary>
+<br>
+  
+```
+pkg i python
+```
+
+</details>
+
+<details>
+<summary> Ubuntu/Debian </summary>
+<br>
+  
+```
+sudo apt install python3
+```
+
+</details>
+
+<details>
+<summary> Fedora </summary>
+<br>
+
+```
+sudo dnf install python3
+```
+</details>
+
+<details>
+<summary> Arch Linux </summary>
+<br>
+
+```
+sudo pacman -S python
+```
+</details>
+
+<h3> Step 2 </h3>
+<p>Create a virual environment for Python under any name you want</p>
+
+```
+python3 -m venv anyname
+```
+<h3> Step 3 </h3>
+<p>Source the approriate variables inside the anyname/bin/ directory for your commandline shell</p>
+
+<details>
+<summary> PowerShell (Windows) </summary>
+<br>
+  
+```
+anyname/bin/activate.ps1
+```
+</details>
+
+<details>
+<summary> bash/zsh (Default on macOS and most Linux systems) </summary>
+<br>
+
+```
+source anyname/bin/activate
+```
+</details>
+
+<details>
+<summary> fish </summary>
+<br>
+
+```
+source anyname/bin/activate.fish
+```
+</details>
+
+<details>
+<summary> tcsh </summary>
+<br>
+
+```
+source anyname/bin/activate.csh
+```
+</details>
+
+<h3> Step 4 </h3>
+
+<p>Install MiUnlockTool</p>
+
+```
 pip install miunlock
 ```
 
-### Quick Install Android(Termux):
+---
+
+### Quick Install for Android(Termux):
 
 ```sh
 curl -sS https://raw.githubusercontent.com/offici5l/MiUnlockTool/main/.install | bash
 ```
 
 ## Usage
+
+Run the command and follow the on-screen insctructions
+
 ```sh
 miunlock
 ```

--- a/README.md
+++ b/README.md
@@ -100,42 +100,46 @@ sudo pacman -S python
 python3 -m venv anyname
 ```
 <h3> Step 3 </h3>
-<p>Source the approriate variables inside the anyname/bin/ directory for your commandline shell</p>
+<p>Source the approriate variables inside the anyname/bin/ directory with your commandline shell. If you're unsure which shell your OS uses run the following command:
+
+```sh
+echo $SHELL
+```
+</p>
 
 <details>
-<summary> PowerShell (Windows) </summary>
+<summary> Windows </summary>
 <br>
   
-```
-anyname/bin/activate.ps1
+```sh
+# PowerShell
+anyname/bin/Activate.ps1
+# CMD
+anyname/bin/activate.bat
 ```
 </details>
 
 <details>
-<summary> bash/zsh (Default on macOS and most Linux systems) </summary>
+<summary> macOS/Linux </summary>
 <br>
 
-```
+Choose the variable file intended for your shell
+
+```sh
+# bash/zsh (Default on macOS and most Linux distributions)
 source anyname/bin/activate
 ```
-</details>
 
-<details>
-<summary> fish </summary>
-<br>
-
-```
+```sh
+# fish
 source anyname/bin/activate.fish
 ```
-</details>
 
-<details>
-<summary> tcsh </summary>
-<br>
-
-```
+```sh
+# tcsh
 source anyname/bin/activate.csh
 ```
+
 </details>
 
 <h3> Step 4 </h3>

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ pkg i python
 <br>
   
 ```
-sudo apt install python3
+sudo apt install python3 python3-venv
 ```
 
 </details>


### PR DESCRIPTION
As far as i know none of the mainstream Linux distributions allow installing packages with pip without a virtual environment, this PR adds instructions for installing MiUnlockTool inside a venv.